### PR TITLE
Handle IPv6 address in http health check

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"strings"
 
@@ -66,7 +67,11 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
 	check := new(consulapi.AgentServiceCheck)
 	if path := service.Attrs["check_http"]; path != "" {
-		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)
+		formatted_ip := service.IP
+		if net.ParseIP(service.IP).To4() == nil { // verify if its an ipv6 address
+			formatted_ip = fmt.Sprintf("[%s]", service.IP)
+		}
+		check.HTTP = fmt.Sprintf("http://%s:%d%s", formatted_ip, service.Port, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -67,11 +67,10 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
 	check := new(consulapi.AgentServiceCheck)
 	if path := service.Attrs["check_http"]; path != "" {
-		formatted_ip := service.IP
 		if net.ParseIP(service.IP).To4() == nil { // verify if its an ipv6 address
-			formatted_ip = fmt.Sprintf("[%s]", service.IP)
+			service.IP = fmt.Sprintf("[%s]", service.IP)
 		}
-		check.HTTP = fmt.Sprintf("http://%s:%d%s", formatted_ip, service.Port, path)
+		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -1,0 +1,30 @@
+package consul
+
+import (
+	"github.com/gliderlabs/registrator/bridge"
+	"testing"
+)
+
+func TestHTTPCheckOnIPv4(t *testing.T) {
+	service := &bridge.Service{}
+	service.IP = "192.168.1.1"
+	service.Port = 80
+	service.Attrs = map[string]string{"check_http": "/foo"}
+	adapter := ConsulAdapter{}
+	check := adapter.buildCheck(service)
+	if check.HTTP != "http://192.168.1.1:80/foo" {
+		t.Error("Bad http url")
+	}
+}
+
+func TestHTTPCheckOnIPv6(t *testing.T) {
+	service := &bridge.Service{}
+	service.IP = "2a00:1450:4013:c01::5e"
+	service.Port = 80
+	service.Attrs = map[string]string{"check_http": "/foo"}
+	adapter := ConsulAdapter{}
+	check := adapter.buildCheck(service)
+	if check.HTTP != "http://[2a00:1450:4013:c01::5e]:80/foo" {
+		t.Error("Bad http url")
+	}
+}


### PR DESCRIPTION
IPv6 address needs to be surrounded by square brackets when calling a
service with the http library (e.g. http://[2a00:1450:4013:c01::5e]:80/foo)
